### PR TITLE
add CCI support

### DIFF
--- a/pine/series_cci.go
+++ b/pine/series_cci.go
@@ -1,0 +1,53 @@
+package pine
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+// CCI generates a ValueSeries of exponential moving average.
+func CCI(tp ValueSeries, l int64) (ValueSeries, error) {
+	key := fmt.Sprintf("cci:%s:%d", tp.ID(), l)
+	cci := getCache(key)
+	if cci == nil {
+		cci = NewValueSeries()
+	}
+
+	tpv := tp.GetCurrent()
+	if tpv == nil {
+		return cci, nil
+	}
+
+	ma, err := SMA(tp, l)
+	if err != nil {
+		return cci, errors.Wrap(err, "error sma")
+	}
+	// need moving average to perform this
+	if ma.GetCurrent() == nil {
+		return cci, nil
+	}
+	mav := ma.GetCurrent().v
+	mdv := tp.SubConst(mav)
+	// get absolute value
+	mdvabs := mdv.Operate(mdv, func(a, b float64) float64 {
+		if a < 0 {
+			return -1 * a
+		}
+		return a
+	})
+	mdvabssum, err := Sum(mdvabs, int(l))
+	if err != nil {
+		return cci, errors.Wrap(err, "error sum mdvabs")
+	}
+	md := mdvabssum.DivConst(float64(l))
+	num := tp.SubConst(mav)
+	denom := md.MulConst(0.015)
+	cci = num.Div(denom)
+
+	setCache(key, cci)
+
+	cci.SetCurrent(tpv.t)
+
+	return cci, nil
+}

--- a/pine/series_cci_test.go
+++ b/pine/series_cci_test.go
@@ -1,0 +1,127 @@
+package pine
+
+import (
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// TestSeriesCCI tests no data scenario
+//
+// t=time.Time (no iteration) | |
+// p=ValueSeries              | |
+// cci=ValueSeries            | |
+func TestSeriesCCI(t *testing.T) {
+
+	data := OHLCVStaticTestData()
+
+	series, err := NewOHLCVSeries(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tp := series.GetSeries(OHLCPropHLC3)
+
+	cci, err := CCI(tp, 3)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "error CCI"))
+	}
+	if cci == nil {
+		t.Error("Expected cci to be non nil but got nil")
+	}
+}
+
+// TestSeriesCCINoIteration tests this sceneario where there's no iteration yet
+
+// t=time.Time (no iteration) | 1  |  2   | 3  | 4  |
+// p=ValueSeries              | 14 |  15  | 17 | 18 |
+// cci=ValueSeries            |    |      |    |    |
+func TestSeriesCCINoIteration(t *testing.T) {
+
+	data := OHLCVStaticTestData()
+
+	series, err := NewOHLCVSeries(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tp := series.GetSeries(OHLCPropHLC3)
+
+	cci, err := CCI(tp, 3)
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "error CCI"))
+	}
+	if cci == nil {
+		t.Error("Expected cci to be non nil but got nil")
+	}
+}
+
+// TestSeriesCCIIteration tests the output against TradingView's expected values
+func TestSeriesCCIIteration(t *testing.T) {
+	data := OHLCVStaticTestData()
+	series, err := NewOHLCVSeries(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []*float64{
+		nil,
+		nil,
+		nil,
+		NewFloat64(-133.3),
+		NewFloat64(65.3),
+		NewFloat64(17.5),
+		NewFloat64(-2.7),
+		NewFloat64(-133.3),
+		NewFloat64(22.2),
+		NewFloat64(-98.6),
+	}
+
+	for i, v := range tests {
+		series.Next()
+		tp := series.GetSeries(OHLCPropHLC3)
+		cci, err := CCI(tp, 4)
+		if err != nil {
+			t.Fatal(errors.Wrap(err, "error cci"))
+		}
+
+		// cci line
+		if (cci.Val() == nil) != (v == nil) {
+			if cci.Val() != nil {
+				t.Errorf("Expected cci to be nil: %t but got %+v for iteration: %d", v == nil, *cci.Val(), i)
+			} else {
+				t.Errorf("Expected cci to be: %+v but got %+v for iteration: %d", *v, cci.Val(), i)
+			}
+			continue
+		}
+		if v != nil && fmt.Sprintf("%.01f", *v) != fmt.Sprintf("%.01f", *cci.Val()) {
+			t.Errorf("Expected cci to be %+v but got %+v for iteration: %d", *v, *cci.Val(), i)
+		}
+	}
+}
+
+func BenchmarkCCI(b *testing.B) {
+	// run the Fib function b.N times
+	start := time.Now()
+	data := OHLCVTestData(start, 10000, 5*60*1000)
+	series, _ := NewOHLCVSeries(data)
+
+	for n := 0; n < b.N; n++ {
+		series.Next()
+		tp := series.GetSeries(OHLCPropHLC3)
+		CCI(tp, 12)
+	}
+}
+
+func ExampleCCI() {
+	start := time.Now()
+	data := OHLCVTestData(start, 10000, 5*60*1000)
+	series, _ := NewOHLCVSeries(data)
+	tp := series.GetSeries(OHLCPropHLC3)
+	cci, err := CCI(tp, 12)
+	if err != nil {
+		log.Fatal(errors.Wrap(err, "error CCI"))
+	}
+	log.Printf("CCI line: %+v", cci.Val())
+}


### PR DESCRIPTION

<summary>Tested using this PineScript code</summary>

<details>

```
// This source code is subject to the terms of the Mozilla Public License 2.0 at https://mozilla.org/MPL/2.0/
// © tak215

//@version=5
indicator("go-pine CCI Test", overlay = false)

openval  = array.from(11.3, 12.9, 11.0, 19.2, 18.1, 19.4, 19.1, 10.6, 18.8, 17.1)
highval  = array.from(19.7, 19.1, 18.8, 19.6, 19.5, 19.8, 19.5, 19.9, 19.0, 17.6)
lowval   = array.from(11.1, 12.3, 10.3, 11.7, 11.2, 13.5, 12.9, 10.3, 12.4, 10.0)
closeval = array.from(16.5, 18.7, 18.2, 11.9, 19.3, 14.2, 14.4, 11.0, 14.7, 10.3)
volumeval= array.from(11.6, 13.0, 13.8, 15.9, 16.8, 19.1, 14.7, 11.7, 17.4, 15.0)

vals (index) =>
    if index >= 0 and array.size(closeval) > index
        [array.get(openval, int(index)),array.get(highval, int(index)),array.get(lowval, int(index)),array.get(closeval, int(index)), array.get(volumeval, int(index))]

sum_test (index) =>
    if index >= 0 and array.size(closeval) > index
        [array.get(openval, int(index)),array.get(highval, int(index)),array.get(lowval, int(index)),array.get(closeval, int(index)), array.get(volumeval, int(index))]

// the same on pine
pine_mfi(src, volsrc, length) =>
    float upper = math.sum(volsrc * (ta.change(src) <= 0.0 ? 0.0 : src), length)
    float lower = math.sum(volsrc * (ta.change(src) >= 0.0 ? 0.0 : src), length)
    mfi = 100.0 - (100.0 / (1.0 + upper / lower))
    mfi


[o, h, l, c, v] = vals(array.size(openval) - (last_bar_index - bar_index))

hlc3v = (h + l + c) / 3

mfi = pine_mfi(hlc3v, v, 4)

cci = ta.cci(hlc3v, 4)

plot(c, color=color.yellow)

plot(cci , color=color.white)

```


</details>